### PR TITLE
Adds Discord webhooks as part of the contact form

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,3 +3,6 @@ SMTP_USERNAME=<username>
 SMTP_PASSWORD=<password>
 SMTP_HOST=<host>
 SMTP_PORT=<port; default is 587>
+DISCORD_WEBHOOK_URL=<see https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks>
+DISCORD_AVATAR_URL=<absolute URL to any public image>
+DISCORD_USERNAME=<displayname for message bot>

--- a/.github/workflows/pull_request_template.md
+++ b/.github/workflows/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+<!--- Describe the change below, including rationale and design decisions -->
+
+## Before/after screenshots and/or animated gif
+<!--- Skip this if not applicable -->
+
+## Testing instructions
+<!--- What steps can be taken to manually verify the changes? -->
+
+## Additional information
+<!--- Check any relevant boxes with "x" -->
+- `[ ]` Changes UI
+- `[ ]` Has associated resource: 
+  <!--- Include any project card, github issue, etc. associated with this PR -->


### PR DESCRIPTION
## Summary
Auto-forward emails sent by users using the `/contact` form to Discord.

Also adds a Pull Request template automatically picked up by GitHub [based on the one used for the game](https://github.com/Studio-Lovelies/GG-JointJustice-Unity/blob/develop/.github/pull_request_template.md).

## Testing instructions
1. Visit https://preview.studio-lovelies.com/contact
2. Send a message
3. Check the internal Discord server for a new message

## Additional information
<!--- Check any relevant boxes with "x" -->
- `[ ]` Changes UI
- `[ ]` Has associated resource: 
  <!--- Include any project card, github issue, etc. associated with this PR -->